### PR TITLE
Typo in the  command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Steps to run the minimal example are:
   5. Open in browser: https://letsmeet.no/test-edumeet-recorder
   6. Use curl to start recording:
 ```
-curl
+curl \
   -i \
   -H "Accept: application/json" \
   -H "Content-Type: application/json" \
@@ -27,7 +27,7 @@ curl
 ```
   7. Use curl stop to stop recording:
 ```
-curl
+curl \
   -i \
   -H "Accept: application/json" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
There was a typo in the `curl` command, missing `\`. I am sorry. I just notice it, so I created a new pull request for that.